### PR TITLE
add metadata for plugin repository

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,7 +15,23 @@ Just select chunk and press `Ctrl+Y` to make the rule
 - Easy customization (see "[Customization](#customization)" section)
 
 ### Installation
-Copy `yarka.py` and `yarka` to your IDA plugins directory (`%IDA_HOME%/plugins`).
+
+#### Using hcli (Recommended)
+The easiest way to install Yarka is using the [Hex-Rays CLI tool (hcli)](https://github.com/HexRaysSA/ida-hcli):
+```bash
+pip install ida-hcli
+hcli plugin install yarka
+```
+
+This will automatically install the plugin to your IDA user directory.
+
+#### Manual Installation
+Alternatively, you can manually install the plugin:
+1. Copy `yarka.py` and the `yarka` folder to your IDA plugins directory
+2. The plugins directory location depends on your system:
+   - **Windows**: `%APPDATA%\Hex-Rays\IDA Pro\plugins\`
+   - **macOS**: `~/Library/Application Support/IDA Pro/plugins/`
+   - **Linux**: `~/.idapro/plugins/`
 
 ### Customization
 You can customize the rules format to suit your needs.

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -2,11 +2,30 @@
     "IDAMetadataDescriptorVersion": 1,
     "plugin": {
       "name": "yarka",
-      "entryPoint": "yarka",
+      "entryPoint": "yarka.py",
       "categories": ["malware-analysis", "ui-ux-and-visualization"],
       "logoPath": "images/logo.png",
       "idaVersions": ">=8.3",
       "description" : "IDA plugin with no dependencies to easily create YARA signatures by selecting a set of instructions, strings or binary data",
-      "version": "0.7.0"
+      "version": "0.7.0",
+      "license": "GPL-3.0",
+      "urls": {
+        "repository": "https://github.com/AzzOnFire/yarka"
+      },
+      "authors": [{
+        "name": "AzzOnFire"
+      }],
+      "keywords": [
+        "yara",
+        "signature-generation",
+        "malware-analysis",
+        "pattern-matching",
+        "rule-creation",
+        "disassembly-selection",
+        "decompiler",
+        "strings-extraction",
+        "hunting-rules",
+        "threat-detection"
+      ]
     }
   }


### PR DESCRIPTION
Thanks for your work on this plugin!

Hex-Rays is developing a plugin manager for IDA Pro plugins. You've probably seen plugins.hex-rays.com but noticed it doesn't really help users get the code configured on their system. This plugin manager is meant to fix that - think of it like `apt` or `pip` for IDA Pro plugins.

The initial version is available via the [Hex-Rays CLI tool (hcli)](https://github.com/HexRaysSA/ida-hcli). You can install it off PyPI like this: `pip install ida-hcli` (note the plugin manager is sitting on a different branch today, sorry!).

From there, users can do things like:

```console
$ hcli plugin search yara
$ hcli plugin install yarka
$ hcli plugin upgrade yarka
$ hcli plugin uninstall yarka
```

For more information about the plugin manager, you can review the documentation here:
https://github.com/HexRaysSA/ida-hcli/blob/plugin-manager/docs/reference/plugins.md

Anyways, to work with the plugin manager, some (hopefully reasonable) changes are needed to yarka. I'm happy to propose changes and help with testing. Don't hesitate to tag me here or email me at wballenthin@hex-rays.com.

Here's what I'd propose:

  - `ida-plugin.json` needs a bit more metadata
  - please consider using GitHub releases to tag new versions, so our indexer can find them

Note: we're in a sort of pre-release time period, where the plugin manager is roughly done
 but the plugin repository isn't fully populated. So I'm doing the pre-work to get a bunch of useful plugins upgraded and indexed. Then we can have a big release and get people excited about easily installing yarka :-)
